### PR TITLE
Update requirements

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -37,6 +37,6 @@ language = English
 status = 3
 
 ### Optional ###
-requirements = numpy stochastic tqdm scipy h5py pandas matplotlib sklearn imageio
+requirements = numpy stochastic tqdm scipy h5py pandas matplotlib scikit-learn imageio
 # dev_requirements =
 # console_scripts =


### PR DESCRIPTION
The PyPI package `sklearn` [has been deprecated](https://pypi.org/project/sklearn/) in favour of `scikit-learn`. This results in an installation error from pip when installing `andi-datasets`. I believe this change should fix the issue 😄 