### PR TITLE
Fixed error with z values

### DIFF
--- a/andi_datasets/utils_videos.py
+++ b/andi_datasets/utils_videos.py
@@ -262,7 +262,7 @@ def transform_to_video(
         "intensity": lambda particle_intensity: particle_intensity[0]
         + np.random.randn() * particle_intensity[1],
         "intensity_variation": 0,  # Intensity variation of particle (in standard deviation)
-        # "z": 0,  # Particles are always at focus
+        "z": None, # Placeholder for z
         "refractive_index": 1.45,  # Refractive index of the particle
         "position_unit": "pixel",
     }
@@ -299,8 +299,8 @@ def transform_to_video(
         number_of_particles=trajectory_data.shape[0],
         traj_length=trajectory_data.shape[1],
         position=lambda trajectory: trajectory[0, :2],
-        z=lambda trajectory: trajectory[0, -1] if trajectory.shape[-1] == 3 else 0,
-        **_particle_dict,
+        z=(_particle_dict['z'] if _particle_dict['z'] is not None else lambda trajectory: trajectory[0, -1] if trajectory.shape[-1] == 3 else 0),
+        **{k: v for k, v in _particle_dict.items() if k != 'z'},
     )
 
     # Intensity variation of particles - controlled by "intensity_variation"


### PR DESCRIPTION
Earlier, we have set all the particles to focus by default. This was achieved by removing the 'z' parameter in `_particle_dict` dictionary, and directly controlling the 'z' parameter in the attributes of the `dt.PointPartcle` as follows:

```
particle = dt.PointParticle(
    ...,
    z=lambda trajectory: trajectory[0, -1] if trajectory.shape[-1] == 3 else 0,
    **_particle_dict,
)
```
The z attribute here checks whether the trajectories are 3D or 2D and applies appropriate conditions. 

However, this approach restricts the ability to change the 'z' positions of the 2D trajectories. Hence, the following changes are proposed.

A place holder `"z": None` is created in the `_particle_dict` dictionary, and the following modifications are added to `dt.PointParticle`

```
particle = dt.PointParticle(
    ...,
    z=(_particle_dict['z'] if _particle_dict['z'] is not None else lambda trajectory: trajectory[0, -1] if trajectory.shape[-1] == 3 else 0),
    **{k: v for k, v in _particle_dict.items() if k != 'z'} # Remove z from the particle dictionary before unpacking
)
```

This way the users can change the 'z' values even for 2D trajectories. However, the users should leave the ´z´value to `None` for 3D trajectories as the trajectories already have those as values.