### PR TITLE
Fix dimension read with a single dict

### DIFF
--- a/andi_datasets/datasets_phenom.py
+++ b/andi_datasets/datasets_phenom.py
@@ -102,7 +102,7 @@ class datasets_phenom(datasets_phenom):
         # Checking and saving the dimension of the models to be generated
         else:
             diff_dims = []
-            for dic in dics:
+            for dic in self.dics:
                 try:
                     diff_dims.append(dic['dim'])
                 except: # dim may not be input as it is not used for some models. In this case, dim = 2

--- a/source_nbs/lib_nbs/datasets_phenom.ipynb
+++ b/source_nbs/lib_nbs/datasets_phenom.ipynb
@@ -176,7 +176,7 @@
     "        # Checking and saving the dimension of the models to be generated\n",
     "        else:\n",
     "            diff_dims = []\n",
-    "            for dic in dics:\n",
+    "            for dic in self.dics:\n",
     "                try:\n",
     "                    diff_dims.append(dic['dim'])\n",
     "                except: # dim may not be input as it is not used for some models. In this case, dim = 2\n",


### PR DESCRIPTION
When creating a dataset with datasets phenom, there are some checks performed to the input dictionaries and they are saved into `self.dics`. However, when looking at the dimension of each input dictionary, the loop is performed over the input `dics` not `self.dics`. This can cause silent bugs whenever there is a single input dictionary, provided that the loop goes over the dictionary keys, causing all the attempts to read the dimension to fail and defaulting to 2D.